### PR TITLE
BUGFIX: PC-360 cinder requires python2-crypto

### DIFF
--- a/openstack-cinder.spec
+++ b/openstack-cinder.spec
@@ -1,4 +1,4 @@
-%define gdc_version .gdc1
+%define gdc_version .gdc2
 %global with_doc %{!?_without_doc:1}%{?_without_doc:0}
 %global pypi_name cinder
 
@@ -97,6 +97,7 @@ Requires:         qemu-img
 Requires:         sysfsutils
 Requires:         os-brick
 Requires:         python-paramiko
+Requires:         python2-crypto
 
 Requires:         python-qpid
 Requires:         python-kombu
@@ -347,6 +348,9 @@ exit 0
 %endif
 
 %changelog
+* Mon May 21 2018 Adam Tkac <adam.tkac@gooddata.com> 8.0.0-1.gdc2
+- cinder requires python2-crypto
+
 * Fri Aug 26 2016 Tomas Dubec <tomas.dubec@gooddata> 8.0.0-1.gdc1
 - adapt spec for GoodData build
 


### PR DESCRIPTION
otherwise startup of the service fails with

2018-05-21 09:27:46.430 14395 ERROR cinder.cmd.volume   File "/usr/lib/python2.7/site-packages/cinder/volume/utils.py", line 24, in <module>
2018-05-21 09:27:46.430 14395 ERROR cinder.cmd.volume     from Crypto.Random import random
2018-05-21 09:27:46.430 14395 ERROR cinder.cmd.volume ImportError: No module named Crypto.Random